### PR TITLE
Replaced python:3.10.11-alpine3.18 with python:3.10.16-slim due to co…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,20 @@
-FROM python:3.10.11-alpine3.18
+FROM python:3.10.16-slim
 
-WORKDIR app/
+WORKDIR /app
 
 COPY requirements.txt requirements.txt
 
-RUN pip3 install --upgrade pip setuptools wheel
-RUN pip3 install --no-warn-script-location --no-cache-dir -r requirements.txt
+RUN apt-get update && apt-get install -y --no-install-recommends \
+       libqt5websockets5 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install --upgrade pip setuptools wheel \
+    && pip3 install --no-warn-script-location --no-cache-dir -r requirements.txt
 
 COPY . .
+
+RUN useradd -ms /bin/bash appuser
+USER appuser
 
 CMD ["python3", "main.py", "-a", "1"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,10 @@ RUN pip3 install --upgrade pip setuptools wheel \
 COPY . .
 
 RUN useradd -ms /bin/bash appuser
+
+RUN chown -R appuser:appuser /app
+RUN chmod -R 755 /app
+
 USER appuser
 
 CMD ["python3", "main.py", "-a", "1"]


### PR DESCRIPTION
Replaced python:3.10.11-alpine3.18 with python:3.10.16-slim due to compatibility issues with PyQt5, which is a dependency of opentele. Alpine-based Python images do not support PyQt5 properly, causing installation failures. Added only the necessary dependencies for PyQt5 and opentele to ensure proper functionality. Also created a non-root user 'appuser' and switched to this user for improved security.